### PR TITLE
Update readme to md with relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ the [`W3C Web Annotation Data Model`](https://www.w3.org/TR/annotation-model/).
 
 The [`OpenAPI Specification`](https://swagger.io/specification/v2/) for the catchpy annotation model can be found at:
 
-    - [/anno/static/anno/catch_api.json](/anno/static/anno/catch_api.json)
+- [/anno/static/anno/catch_api.json](/anno/static/anno/catch_api.json)
 
 A jsonld serialization of this model can be found at:
 
-    - [catch_context_jsonld.json](https://catchpy.harvardx.harvard.edu.s3.amazonaws.com/jsonld/catch_context_jsonld.json)
+- [catch_context_jsonld.json](https://catchpy.harvardx.harvard.edu.s3.amazonaws.com/jsonld/catch_context_jsonld.json)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
-catchpy
-=======
+# catchpy
 
 HarvardX annotations storage API
 
 
-Overview
---------
+## Overview
 
 catchpy is part of AnnotationsX, HarvardX implementation of annotations using
-the `W3C Web Annotation Data Model`_.
+the [`W3C Web Annotation Data Model`](https://www.w3.org/TR/annotation-model/).
 
-The `OpenAPI Specification`_ for the catchpy annotation model can be found at:
+The [`OpenAPI Specification`](https://swagger.io/specification/v2/) for the catchpy annotation model can be found at:
 
     - [/anno/static/anno/catch_api.json](/anno/static/anno/catch_api.json)
 
 A jsonld serialization of this model can be found at:
 
-    - https://catchpy.harvardx.harvard.edu.s3.amazonaws.com/jsonld/catch_context_jsonld.json
+    - [catch_context_jsonld.json](https://catchpy.harvardx.harvard.edu.s3.amazonaws.com/jsonld/catch_context_jsonld.json)
 
 
 
-Quick Start
------------
+## Quick Start
 
 For those who want to quickly check out what catchpy does.
 
-Make sure you have docker_ installed to try this quickstart.
-
-::
+Make sure you have [docker](https://www.docker.com) installed to try this quickstart.
 
     # clone this repo
     $> git clone https://github.com/nmaekawa/catchpy.git
@@ -40,10 +35,10 @@ Make sure you have docker_ installed to try this quickstart.
     $> open http://localhost:8000/static/anno/index.html
 
 
-This last command opens the API page, where you can try the `Web Annotation`_
-and the back-compat AnnotatorJS_ APIs.
+This last command opens the API page, where you can try the [`Web Annotation`](https://www.w3.org/TR/annotation-model/)
+and the back-compat [AnnotatorJS](http://annotatorjs.org) APIs.
 
-To actually issue rest requests, you will need a jwt_ token. Generate one
+To actually issue rest requests, you will need a [jwt](https://jwt.io) token. Generate one
 like below::
 
     # this generates a consumer/secret api key
@@ -66,8 +61,7 @@ into the API page, by clicking on the lock at the right of each API call, or on
 the ``Authorize`` button at the top right of the page.
 
 
-Not So Quick Start
-------------------
+## Not So Quick Start
 
 For those who want to set up a local instance of catchpy, for tests or
 developement.
@@ -76,8 +70,6 @@ Setting up catchpy locally requires:
 
     - postgres 9.6 or higher
     - python 3.5 or higher
-
-::
 
     # clone this repo
     $> git clone https://github.com/nmaekawa/catchpy.git
@@ -130,8 +122,7 @@ You probably know this: ``./manage.py runserver`` is **not for production**
 deployment, use for development environment only!
 
 
-Run unit tests
----------------
+## Run unit tests
 
 unit tests require:
 
@@ -144,8 +135,6 @@ unit tests require:
 
 tests are located under each django app:
 
-::
-
     # tests for annotations
     CATCHPY_DOTENV_PATH=/path/to/dotenv/file pytest -v anno/tests
 
@@ -154,18 +143,3 @@ tests are located under each django app:
 
     # or use tox
     CATCHPY_DOTENV_PATH=/path/to/dotenv/file tox
-
-
----eop
-
-
-.. _W3C Web Annotation Data Model: https://www.w3.org/TR/annotation-model/
-.. _OpenAPI Specification: https://swagger.io/specification/v2/
-.. _docker: https://www.docker.com
-.. _Web Annotation: https://www.w3.org/TR/annotation-model/
-.. _AnnotatorJS: http://annotatorjs.org
-.. _jwt: https://jwt.io
-
-
-
-

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ the `W3C Web Annotation Data Model`_.
 
 The `OpenAPI Specification`_ for the catchpy annotation model can be found at:
 
-    - https://raw.githubusercontent.com/nmaekawa/catchpy/master/anno/static/anno/catch_api.json
+    - [/anno/static/anno/catch_api.json](/anno/static/anno/catch_api.json)
 
 A jsonld serialization of this model can be found at:
 


### PR DESCRIPTION
This is part of renaming the default branch of the repository to `main`. There aren't functional references to the branch name that I could find, but in looking for them, I found a hard-coded internal link that relies on the repository and branch. GitHub Markdown supports [relative links to internal files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files) in its markdown syntax, so I remade the readme from an `.rst` file to an `.md` file.