### PR TITLE
updated pyscopg2

### DIFF
--- a/catchpy/requirements/base.txt
+++ b/catchpy/requirements/base.txt
@@ -1,7 +1,7 @@
 Django==2.2.11
 iso8601==0.1.12
 jsonschema==3.0.1
-psycopg2==2.8.4
+psycopg2==2.9.6
 PyJWT==1.7.1
 PyLD==1.0.5
 python-dateutil==2.8.1


### PR DESCRIPTION
This PR is to update `pyscopg2` due to failing docker build. The `psycopg2` build wheel errors out before the build completes.
Example of the error:
```bash
Building wheel for psycopg2 (setup.py): finished with status 'error'
error: subprocess-exited-with-error
```